### PR TITLE
Fix thread usage while initialisation and workaround setFocus bug

### DIFF
--- a/lib/watobo/gui.rb
+++ b/lib/watobo/gui.rb
@@ -2,6 +2,7 @@ begin
   print "\nLoading FXRuby ... this may take some time ... "
   require 'fox16'
   require 'fox16/colors'
+  require 'watobo/patch_fxruby_setfocus'
   print "[OK]\n"
 rescue LoadError
   print "[FAILED]\n"

--- a/lib/watobo/gui/main_window.rb
+++ b/lib/watobo/gui/main_window.rb
@@ -57,40 +57,28 @@ module Watobo#:nodoc: all
          @scanner = nil
       end
     end
-    
+
     @chat_lock.synchronize do
       @chat_queue.each do |c|
         addChat(c)
       end
       @chat_queue.clear
     end
-    
+
     @status_lock.synchronize do
       unless @new_status.nil?
         update_status(@new_status)
       end
-        
+
     end
-    
-    @msg_lock.synchronize do
-      while @msg_queue.length > 0
-        msg = @msg_queue.shift
-        case msg
-        when :modal_finished
-          puts "stopping modal ..."
-          getApp.stopModal
-          puts "modal stopped"
-        end
-      end
-    end
-    
+
   }
  end
 
       def update_status(new_status)
         case new_status
         when SCAN_STARTED
-          
+
         when SCAN_FINISHED
           @scan_button.icon = ICON_START
           @dashboard.setScanStatus("Finished")
@@ -786,40 +774,37 @@ module Watobo#:nodoc: all
             puts bang.backtrace if $DEBUG
             puts "!!! Could not create project :("
           ensure
-          puts "* stop modal mode" if $DEBUG
-          @msg_lock.synchronize do
-          #getApp.stopModal
-          @msg_queue << :modal_finished
+            puts "* stop modal mode" if $DEBUG
+            runOnUiThread do
+              getApp.stopModal
+            end
           end
-
-          end
-
         }
         getApp().runModal
-      
-      
-       update_conversation_table()
-       update_status_bar()
-       puts "* starting interceptor"
-       Watobo::Interceptor.start
-       puts "* starting passive scanner"
-       Watobo::PassiveScanner.start
-       @browserView = BrowserPreview.new(Watobo::Interceptor.proxy)
-       
-       #  be sure to hide the progress window      
-       @progress_window.destroy
-       
-       
-       @chatTable.show
-       @sites_tree.show
-       @sites_tree.reload
-       @findings_tree.show
-       @findings_tree.reload
-       
-       @chatTable.apply_filter(@conversation_table_ctrl.filter)
-       @conversation_table_ctrl.update_text
-       
-        
+
+
+        update_conversation_table()
+        update_status_bar()
+        puts "* starting interceptor"
+        Watobo::Interceptor.start
+        puts "* starting passive scanner"
+        Watobo::PassiveScanner.start
+        @browserView = BrowserPreview.new(Watobo::Interceptor.proxy)
+
+        #  be sure to hide the progress window
+        @progress_window.destroy
+
+
+        @chatTable.show
+        @sites_tree.show
+        @sites_tree.reload
+        @findings_tree.show
+        @findings_tree.reload
+
+        @chatTable.apply_filter(@conversation_table_ctrl.filter)
+        @conversation_table_ctrl.update_text
+
+
         puts "Project Started"
         puts "Active Modules: #{Watobo::ActiveModules.length}"
         puts "Passive Modules: #{Watobo::PassiveModules.length}"
@@ -1176,7 +1161,6 @@ module Watobo#:nodoc: all
         @finding_lock = Mutex.new
         @chat_lock = Mutex.new
         @status_lock = Mutex.new
-        @msg_lock = Mutex.new
 
         @finding_queue = []
         @chat_queue = []

--- a/lib/watobo/gui/utils/load_plugins.rb
+++ b/lib/watobo/gui/utils/load_plugins.rb
@@ -37,7 +37,9 @@ module Watobo#:nodoc: all
               load pgf
               class_constant = Watobo.class_eval(class_name)
 
-              Watobo::Gui.add_plugin class_constant.new(Watobo::Gui.application, project)
+              Watobo::Gui.application.runOnUiThread do
+                Watobo::Gui.add_plugin class_constant.new(Watobo::Gui.application, project)
+              end
             else
 
               Dir["#{sub}/#{File.basename(sub)}.rb"].each do |plugin_file|
@@ -76,8 +78,9 @@ module Watobo#:nodoc: all
                   #puts class_name
                   class_constant = Watobo.class_eval(class_name)
 
-                  Watobo::Gui.add_plugin class_constant.new(Watobo::Gui.application, project)
-                  
+                  Watobo::Gui.application.runOnUiThread do
+                    Watobo::Gui.add_plugin class_constant.new(Watobo::Gui.application, project)
+                  end
                 rescue => bang
                   puts bang
                   puts bang.backtrace if $DEBUG
@@ -88,15 +91,17 @@ module Watobo#:nodoc: all
 
               Watobo::Plugin.constants.each do |pc|
                 puts ">> PLUGIN >> #{pc.to_s}"
-                
+
                 pclass = Watobo::Plugin.class_eval(pc.to_s)
-                
+
                 if pclass.respond_to? :create_gui
                   puts "ADD NEW PLUGIN #{pc.upcase}"
                   # TODO: In later versions - if all plugins are switched to the new style - this will not be necessary here
-                  gui = pclass.create_gui()
-                  # puts gui.class
-                  Watobo::Gui.add_plugin pclass
+                  Watobo::Gui.application.runOnUiThread do
+                    gui = pclass.create_gui()
+                    # puts gui.class
+                    Watobo::Gui.add_plugin pclass
+                  end
 
                 # exit
                 end

--- a/lib/watobo/patch_fxruby_setfocus.rb
+++ b/lib/watobo/patch_fxruby_setfocus.rb
@@ -1,0 +1,27 @@
+# Work around error 'FXComposeContext: illegal window parameter'
+# in FXWindow#setFocus of some libfox versions.
+
+class Fox::FXWindow
+  def setFocus
+    app.addChore do
+      super
+    end
+  end
+end
+
+class Fox::FXDialogBox
+  def setFocus
+    app.addChore do
+      super
+    end
+  end
+end
+
+class Fox::FXTextField
+  def setFocus
+    app.addChore do
+      super
+    end
+  end
+end
+


### PR DESCRIPTION
I had some trouble in getting watobo running on Ubuntu-15.04. I'm using system libfox-1.6.50 and fxruby-1.6.33 on ruby-2.2.0 installed per rvm.

One issue is caused by doing GUI operations outside of the main thread, while initialization. This is generally not safe in fxruby (and also not safe in most other GUI frameworks, too) and can lead to GUI starvation or X-Windows/Win32-GDI errors. So all GUI related things like adding/removing widgets, changing values, popup message boxes, etc. must be done in the main thread. Luckily fxruby has runOnUiThread to make this easy from a different thread.

I've putted the GUI operations I'm aware of into runOnUiThread blocks, but I'm not sure if this addresses all places correctly. There are presumably other thread misusages in other parts of the program.

The other commit is about use of setFocus before widget creation. This is a libfox bug, but I generally work around this bug by using setFocus only in addChore blocks. I didn't test which versions of libfox are affected, but obviously libfox-1.6.50 is.
